### PR TITLE
Updating API Docs Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ## API Docs
 
-- <https://ipfs.github.io/helia-unixfs>
+- [https://ipfs.github.io/helia-unixfs](https://ipfs.github.io/helia-unixfs/modules/_helia_unixfs.html)
 
 ## License
 


### PR DESCRIPTION
Currently when we go to api docs url  it shows an empty page.. instead of this it should get redirect to the actual docs page which is "https://ipfs.github.io/helia-unixfs/modules/_helia_unixfs.html"

Current URL - https://ipfs.github.io/helia-unixfs
![image](https://github.com/ipfs/helia-unixfs/assets/98685642/075a6270-3658-4f74-8806-fb7e4c47c15a)

Updated URL - https://ipfs.github.io/helia-unixfs/modules/_helia_unixfs.html
![image](https://github.com/ipfs/helia-unixfs/assets/98685642/8cb112b1-05ae-432e-a617-628f72a1ffbe)

