### PR TITLE
docs: fix typos in example code

### DIFF
--- a/packages/unixfs/src/index.ts
+++ b/packages/unixfs/src/index.ts
@@ -401,7 +401,7 @@ export interface UnixFS {
    *
    * ```typescript
    * const cid = await fs.addFile({
-   *   path: './foo.txt'
+   *   path: './foo.txt',
    *   content: Uint8Array.from([0, 1, 2, 3]),
    *   mode: 0x755,
    *   mtime: {
@@ -482,7 +482,7 @@ export interface UnixFS {
    *
    * ```typescript
    * for await (const entry of fs.ls(directoryCid)) {
-   *   console.info(etnry)
+   *   console.info(entry)
    * }
    * ```
    */


### PR DESCRIPTION
path: './foo.txt' miss a comma,
’entry‘ was written as "etnry"...