### PR TITLE
fix: correct browser override path for glob-source

### DIFF
--- a/packages/unixfs/package.json
+++ b/packages/unixfs/package.json
@@ -189,7 +189,7 @@
     "entryPoint": "./src/index.ts"
   },
   "browser": {
-    "./dist/utils/glob-source.js": false,
+    "./dist/src/utils/glob-source.js": false,
     "node:fs": false,
     "node:fs/promises": false,
     "node:path": false,


### PR DESCRIPTION
The file is imported from `dist/src/utils`