### PR TITLE
chore: use ts-ignore for go-ipfs import

### DIFF
--- a/packages/interop/test/fixtures/create-kubo.ts
+++ b/packages/interop/test/fixtures/create-kubo.ts
@@ -1,5 +1,6 @@
 
-// @ts-expect-error no types
+/* eslint-disable @typescript-eslint/ban-ts-comment,@typescript-eslint/prefer-ts-expect-error */
+// @ts-ignore no types - TODO: remove me once the next version of npm-go-ipfs has shipped
 import * as goIpfs from 'go-ipfs'
 import { type Controller, type ControllerOptions, createController } from 'ipfsd-ctl'
 import * as kuboRpcClient from 'kubo-rpc-client'


### PR DESCRIPTION
The next version of npm-go-ipfs has types so the @ts-expect-error prevents using the pre-release version of npm-go-ipfs.